### PR TITLE
Switch to maintained qrcodejs fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "vue": "^2.0.1",
-    "qrcode-js-package": "^1.0.4"
+    "@keeex/qrcodejs-kx": "^1.0.2"
   },
   "browserify": {
     "transform": [

--- a/src/QRCode.vue
+++ b/src/QRCode.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script>
-    import QRCode from 'qrcode-js-package/qrcode.js'
+    import QRCode from '@keeex/qrcodejs-kx'
     export default {
 
         props: {


### PR DESCRIPTION
[davidshimjs/qrcodejs](https://github.com/davidshimjs/qrcodejs) has not received an update in 4 years. There is a [code length overflow bug](https://github.com/davidshimjs/qrcodejs/issues/78) that  breaks QR code generation when the text is within a certain character range.

This PR switches to the [KeeeX/qrcodejs](https://github.com/KeeeX/qrcodejs) fork, which fixes this bug, contains additional cleanup, and appears to be more actively maintained.